### PR TITLE
fix crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
  - source: /messages/en.json
-  translation: /messages/%two_letters_code%.json
+   translation: /messages/%two_letters_code%.json


### PR DESCRIPTION
Fix indentation in crowdin.yml in order to set the integration between Crowdin and Github.